### PR TITLE
(Fix) Remove 'init' from gulp command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use this project as is, first clone the repo from GitHub, then run:
 $ cd ionic-app-base
 $ sudo npm install -g cordova ionic gulp
 $ npm install
-$ gulp init
+$ gulp
 ```
 
 ## Using Sass (optional)


### PR DESCRIPTION
When running `gulp init`, I got the following error message:
`[17:54:34] Task 'init' is not in your gulpfile`

The default tasks run whenever you just run the `gulp` command, thus, I removed `init` from `gulp init`.